### PR TITLE
Fix typo in arrange_.tbl_lazy, fixes dplyr#2700

### DIFF
--- a/R/tbl-lazy.R
+++ b/R/tbl-lazy.R
@@ -76,7 +76,7 @@ arrange.tbl_lazy <- function(.data, ...) {
 }
 #' @export
 arrange_.tbl_lazy <- function(.data, ..., .dots = list()) {
-  dots <- dplyr:::compat_lazy_dots(dots, caller_env(), ...)
+  dots <- dplyr:::compat_lazy_dots(.dots, caller_env(), ...)
   arrange(.data, !!! dots)
 }
 


### PR DESCRIPTION
I'm pretty sure you closed dplyr #2700 in error so dove a little bit deeper.

This looks like a pretty clear typo to me. I  know that that the underscore functions are deprecated, but this will allow me to  support both 0.5 and 0.6 more easily.

Thanks!